### PR TITLE
Feat: Implement White-Labeling Functionality

### DIFF
--- a/WHITE_LABEL_GUIDE.md
+++ b/WHITE_LABEL_GUIDE.md
@@ -1,0 +1,66 @@
+# AssetArc White-Labeling Guide for Advisors
+
+Welcome to the AssetArc White-Labeling Program! This guide explains how you can leverage our powerful platform under your own brand, providing a seamless experience for your clients.
+
+---
+
+## 1. What is White-Labeling?
+
+The white-label feature allows you to present the AssetArc client portal, document vault, and other client-facing tools as if they were your own. When your clients log in to generate documents or access their vault, they will see **your firm's logo and branding**, not ours.
+
+This enables you to:
+-   **Strengthen Your Brand:** Maintain a consistent brand experience throughout your client's journey.
+-   **Build Client Trust:** Offer a professional, integrated solution that appears as a core part of your advisory services.
+-   **Leverage Our Technology:** Utilize AssetArc's powerful compliance and automation engine without the cost and complexity of building it yourself.
+
+---
+
+## 2. How It Works: Your Custom Portal
+
+Your white-labeled portal is delivered through a custom subdomain. Once configured, you and your clients will access the platform through a unique URL:
+
+`your-brand.asset-arc.com`
+
+For example, if your firm is named "Acme Financial Advisors", your portal would be accessible at `acme-financial-advisors.asset-arc.com`.
+
+All pages viewed through this address, from the login screen to the document vault, will be branded with your firm's assets.
+
+---
+
+## 3. The Setup Process
+
+Getting your white-labeled portal set up is a simple, one-time process.
+
+**Step 1: Contact Us**
+Reach out to the AssetArc platform administrator. You will need to provide the following:
+
+*   **Your desired Brand ID:** This will be used for your subdomain (e.g., `acme-financial-advisors`). It should be unique and contain only letters, numbers, and hyphens.
+*   **Your Brand Name:** The official name of your firm (e.g., "Acme Financial Advisors").
+*   **Your Logo:** A high-resolution image file (PNG, SVG, or JPG) of your company logo.
+*   **(Optional) Your Primary Brand Color:** A hex code (e.g., `#0047AB`) for your primary brand color, which may be used for accents in the future.
+
+**Step 2: Configuration**
+Our team will configure your brand in our backend system and activate your unique subdomain.
+
+**Step 3: Go-Live!**
+Once configured, we will notify you that your portal is live. You can then begin directing your clients to your new branded URL.
+
+---
+
+## 4. The Client Experience
+
+Your clients will enjoy the full power of the AssetArc platform, but with your brand front and center. When you send them an invitation or a link to the portal, they will be taken to `your-brand.asset-arc.com`, where they will see your logo in the header of every page.
+
+This ensures a consistent and trustworthy experience, reinforcing the value of your services.
+
+---
+
+## 5. Coming Soon: Your Advisor Dashboard
+
+As part of the white-label program, you will soon have access to your own dedicated KPI dashboard. This will provide you with valuable insights into:
+
+-   Your clients' activity and document generation.
+-   Your token usage and remaining balance.
+-   Revenue and profitability metrics specific to your client base.
+
+Thank you for being a valued AssetArc partner!

--- a/assetarc-theme/header.php
+++ b/assetarc-theme/header.php
@@ -28,10 +28,21 @@
   <div class="container header-container">
     <div class="site-logo">
       <?php
-      if (has_custom_logo()) {
-          the_custom_logo();
+      // Attempt to get white-label brand assets
+      $brand_assets = get_assetarc_brand_assets();
+
+      if (isset($brand_assets['logo_url']) && !empty($brand_assets['logo_url'])) {
+          // If a white-label logo exists, display it
+          echo '<a href="' . esc_url(home_url('/')) . '" rel="home">';
+          echo '<img src="' . esc_url($brand_assets['logo_url']) . '" alt="' . esc_attr($brand_assets['name']) . ' Logo" style="height: 60px; width: auto;">';
+          echo '</a>';
       } else {
-          echo '<h1 style="color:#FFD700;">' . get_bloginfo('name') . '</h1>';
+          // Fallback to the default WordPress custom logo or site title
+          if (has_custom_logo()) {
+              the_custom_logo();
+          } else {
+              echo '<h1 style="color:#FFD700;">' . get_bloginfo('name') . '</h1>';
+          }
       }
       ?>
     </div>

--- a/reverse-proxy/nginx.sample.conf
+++ b/reverse-proxy/nginx.sample.conf
@@ -14,3 +14,35 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+
+# --- White-Labeling Server Block ---
+# This server block handles requests for white-labeled client portals.
+#
+# PREREQUISITES:
+# 1. You must have a wildcard DNS record set up for your domain.
+#    For example, an A record for `*.asset-arc.com` pointing to this server's IP address.
+# 2. You must have a wildcard SSL certificate for `*.asset-arc.com`.
+#
+server {
+    listen 443 ssl http2;
+    # This server_name uses a regular expression to capture the subdomain part.
+    # e.g., for "acme-advisors.asset-arc.com", $brand_id will be "acme-advisors".
+    server_name ~^(?<brand_id>.+)\.asset-arc\.com$;
+
+    ssl_certificate     /etc/letsencrypt/live/asset-arc.com/fullchain.pem; # Path to your WILDCARD cert
+    ssl_certificate_key /etc/letsencrypt/live/asset-arc.com/privkey.pem; # Path to your WILDCARD key
+
+    location / {
+        # This is the crucial part for white-labeling.
+        # It passes the captured subdomain to the upstream WordPress application
+        # as a custom HTTP header.
+        proxy_set_header X-AssetArc-Brand-ID $brand_id;
+
+        # Standard proxy settings
+        proxy_pass http://127.0.0.1:8080; # Assuming WordPress is running on port 8080
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
This commit introduces the initial version of the white-labeling feature, allowing advisors to present the platform under their own brand.

The implementation uses a subdomain-based approach (`brand-id.asset-arc.com`) to determine which brand to display.

Key changes include:

1.  **Backend (`eng-identity`):**
    -   Added `brands` and `advisor_brands` tables to the database to store branding information and link advisors to brands.
    -   Created a new API endpoint, `GET /api/v1/brands/<brand_id>`, to serve branding assets (logo URL, colors, etc.).
    -   Added passing unit tests for the new endpoint.

2.  **Infrastructure (`reverse-proxy`):**
    -   Updated `nginx.sample.conf` with a documented example of how to configure Nginx to capture the subdomain and pass it to the application as a custom `X-AssetArc-Brand-ID` header.

3.  **Frontend (`assetarc-theme`):**
    -   Modified `functions.php` to read the `X-AssetArc-Brand-ID` header and fetch brand data from the new API endpoint.
    -   Updated `header.php` to dynamically display the fetched brand logo, with a fallback to the default logo.

4.  **Documentation:**
    -   Created `WHITE_LABEL_GUIDE.md` to explain the feature and setup process to advisors.