### PR TITLE
This commit introduces the International Tax / Residency Planner tool.

### DIFF
--- a/Services/eng-compliance/app/app.py
+++ b/Services/eng-compliance/app/app.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ValidationError
 from .modules import (
     run_s42_47_check, run_bbee_scorecard_check,
     run_estate_duty_check, run_succession_check,
-    run_insurance_wrapper_check
+    run_insurance_wrapper_check, run_residency_planner_check
 )
 
 app = Flask(__name__)
@@ -16,6 +16,7 @@ BEE_CALCULATOR_ENABLED = os.getenv('BEE_CALCULATOR_ENABLED', 'false').lower() ==
 ESTATE_CALCULATOR_ENABLED = os.getenv('ESTATE_CALCULATOR_ENABLED', 'false').lower() == 'true'
 SUCCESSION_PLANNER_ENABLED = os.getenv('SUCCESSION_PLANNER_ENABLED', 'false').lower() == 'true'
 INSURANCE_WRAPPER_CALCULATOR_ENABLED = os.getenv('INSURANCE_WRAPPER_CALCULATOR_ENABLED', 'false').lower() == 'true'
+RESIDENCY_PLANNER_ENABLED = os.getenv('RESIDENCY_PLANNER_ENABLED', 'false').lower() == 'true'
 
 
 # --- Module Router ---
@@ -34,6 +35,8 @@ if SUCCESSION_PLANNER_ENABLED:
     COMPLIANCE_MODULES["succession_planner"] = run_succession_check
 if INSURANCE_WRAPPER_CALCULATOR_ENABLED:
     COMPLIANCE_MODULES["insurance_wrapper_calculator"] = run_insurance_wrapper_check
+if RESIDENCY_PLANNER_ENABLED:
+    COMPLIANCE_MODULES["residency_planner"] = run_residency_planner_check
 
 # --- Models for Request Validation ---
 class ComplianceRunBody(BaseModel):

--- a/Services/eng-compliance/app/modules.py
+++ b/Services/eng-compliance/app/modules.py
@@ -6,6 +6,24 @@ from pydantic import ValidationError
 from .bbee import OwnershipStructure, calculate_ownership_scorecard
 from .estate_calculator import EstateInput, calculate_estate_duty
 from .insurance_wrapper_calculator import InsuranceWrapperInput, calculate_wrapper_benefit
+from .residency_planner import ResidencyPlannerInput, determine_residency_status
+
+def run_residency_planner_check(inputs: dict) -> dict:
+    """
+    Parses user data and runs the Tax Residency Planner.
+    """
+    try:
+        planner_input = ResidencyPlannerInput(**inputs)
+        result = determine_residency_status(planner_input)
+        return {
+            "status": "completed",
+            "summary": f"Your determined tax residency status is: {result['status']}",
+            "details": result
+        }
+    except ValidationError as e:
+        return {"status": "error", "summary": "Input data is invalid.", "details": e.errors()}
+    except Exception as e:
+        return {"status": "error", "summary": "An unexpected error occurred.", "details": str(e)}
 
 def run_insurance_wrapper_check(inputs: dict) -> dict:
     """

--- a/Services/eng-compliance/app/residency_planner.py
+++ b/Services/eng-compliance/app/residency_planner.py
@@ -1,0 +1,90 @@
+"""
+This module contains the logic for the South African Tax Residency Planner.
+It implements the Ordinary Residence Test and the Physical Presence Test
+as defined in the Income Tax Act.
+"""
+from pydantic import BaseModel, Field, validator
+from typing import List, Optional
+
+class OrdinaryResidenceFlags(BaseModel):
+    """Flags representing ties to South Africa for the Ordinary Residence Test."""
+    has_permanent_home: bool = Field(..., description="Does the person have a permanent home available in SA?")
+    has_family_ties: bool = Field(..., description="Are the person's immediate family (spouse, children) in SA?")
+    has_economic_ties: bool = Field(..., description="Are the person's main economic interests (business, assets) in SA?")
+    intends_to_return: bool = Field(..., description="Does the person intend to return to SA as their real home?")
+
+class ResidencyPlannerInput(BaseModel):
+    """Input model for the residency planner calculator."""
+    days_in_current_year: int = Field(..., ge=0, le=366, description="Number of days physically present in SA in the current tax year.")
+    days_each_of_prev_5_years: List[int] = Field(..., min_items=5, max_items=5, description="A list of days present in each of the 5 preceding tax years.")
+    ordinary_residence_flags: OrdinaryResidenceFlags
+    days_continuously_absent: Optional[int] = Field(None, ge=0, description="For the exit rule, the number of continuous days spent outside SA.")
+
+    @validator('days_each_of_prev_5_years')
+    def check_days_in_year(cls, v):
+        for days in v:
+            if not (0 <= days <= 366):
+                raise ValueError('Days in any given year must be between 0 and 366.')
+        return v
+
+def determine_residency_status(inputs: ResidencyPlannerInput):
+    """
+    Determines tax residency status based on the provided inputs.
+    Follows the logic flow: Ordinary Residence -> Physical Presence -> Exit Rule.
+    """
+    # --- Step 1: Ordinary Residence Test ---
+    # This is a subjective test. For this tool, we'll use a rule-based heuristic.
+    # If the user has strong ties (e.g., 3 or more flags), we consider them ordinarily resident.
+    flags = inputs.ordinary_residence_flags
+    true_flags_count = sum([
+        flags.has_permanent_home,
+        flags.has_family_ties,
+        flags.has_economic_ties,
+        flags.intends_to_return
+    ])
+
+    if true_flags_count >= 3:
+        return {
+            "status": "Resident",
+            "reasoning": "You are considered ordinarily resident in South Africa due to your significant personal and economic ties.",
+            "advice": "As a resident, you are subject to SA tax on your worldwide income. You may be able to claim foreign tax credits for tax paid in other countries. A Double Tax Agreement (DTA) may apply."
+        }
+
+    # --- Step 2: Physical Presence Test ---
+    physically_resident = False
+    test_conditions = {
+        "current_year_test": inputs.days_in_current_year >= 91,
+        "preceding_years_test": all(d >= 91 for d in inputs.days_each_of_prev_5_years),
+        "total_days_test": sum(inputs.days_each_of_prev_5_years) >= 915
+    }
+
+    if all(test_conditions.values()):
+        physically_resident = True
+
+    # --- Step 3: Exit Rule (330-day rule) ---
+    if physically_resident and inputs.days_continuously_absent is not None:
+        if inputs.days_continuously_absent >= 330:
+            return {
+                "status": "Non-Resident",
+                "reasoning": "Although you met the physical presence test, you have since been continuously outside of South Africa for at least 330 days, which ceases your tax residency from the date of departure.",
+                "advice": "As a non-resident, you are generally only taxed on income sourced from South Africa."
+            }
+
+    # --- Final Determination ---
+    if physically_resident:
+        return {
+            "status": "Resident",
+            "reasoning": "You meet the requirements of the physical presence test (the day-counting test).",
+            "advice": "As a resident, you are subject to SA tax on your worldwide income. You may be able to claim foreign tax credits. A Double Tax Agreement (DTA) may also apply. If you remain outside SA for a continuous period of 330 days, you will cease to be a resident."
+        }
+
+    # If neither test is met
+    reasoning_details = [f"Days in current year >= 91: {'Pass' if test_conditions['current_year_test'] else 'Fail'}",
+                         f"Days in each of past 5 years >= 91: {'Pass' if test_conditions['preceding_years_test'] else 'Fail'}",
+                         f"Total days in past 5 years >= 915: {'Pass' if test_conditions['total_days_test'] else 'Fail'}"]
+
+    return {
+        "status": "Non-Resident",
+        "reasoning": f"You do not meet the requirements for ordinary residence or the physical presence test. Failures: {', '.join([r for r in reasoning_details if 'Fail' in r])}",
+        "advice": "As a non-resident, you are generally only taxed on income sourced from South Africa."
+    }

--- a/Services/eng-compliance/tests/test_insurance_wrapper_calculator.py
+++ b/Services/eng-compliance/tests/test_insurance_wrapper_calculator.py
@@ -3,8 +3,12 @@ import json
 from unittest import TestCase
 from unittest.mock import patch
 
-# It's crucial to set the feature flag *before* importing the app
+# Set all feature flags to true for a consistent testing environment
+os.environ['BEE_CALCULATOR_ENABLED'] = 'true'
+os.environ['ESTATE_CALCULATOR_ENABLED'] = 'true'
+os.environ['SUCCESSION_PLANNER_ENABLED'] = 'true'
 os.environ['INSURANCE_WRAPPER_CALCULATOR_ENABLED'] = 'true'
+os.environ['RESIDENCY_PLANNER_ENABLED'] = 'true'
 
 from app.app import app
 

--- a/Services/eng-compliance/tests/test_residency_planner.py
+++ b/Services/eng-compliance/tests/test_residency_planner.py
@@ -1,0 +1,121 @@
+import os
+import json
+from unittest import TestCase
+
+# Set all feature flags to true for a consistent testing environment
+os.environ['BEE_CALCULATOR_ENABLED'] = 'true'
+os.environ['ESTATE_CALCULATOR_ENABLED'] = 'true'
+os.environ['SUCCESSION_PLANNER_ENABLED'] = 'true'
+os.environ['INSURANCE_WRAPPER_CALCULATOR_ENABLED'] = 'true'
+os.environ['RESIDENCY_PLANNER_ENABLED'] = 'true'
+
+from app.app import app
+
+class TestResidencyPlanner(TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+        self.base_payload = {
+            "module_id": "residency_planner",
+            "inputs": {
+                "days_in_current_year": 0,
+                "days_each_of_prev_5_years": [0, 0, 0, 0, 0],
+                "ordinary_residence_flags": {
+                    "has_permanent_home": False,
+                    "has_family_ties": False,
+                    "has_economic_ties": False,
+                    "intends_to_return": False
+                },
+                "days_continuously_absent": None
+            }
+        }
+
+    def test_ordinarily_resident(self):
+        """Test a user who is clearly ordinarily resident."""
+        payload = self.base_payload.copy()
+        payload['inputs']['ordinary_residence_flags'] = {
+            "has_permanent_home": True,
+            "has_family_ties": True,
+            "has_economic_ties": True,
+            "intends_to_return": True
+        }
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['result']['details']['status'], 'Resident')
+        self.assertIn('ordinarily resident', data['result']['details']['reasoning'])
+
+    def test_physical_presence_pass(self):
+        """Test a user who passes the physical presence test (user's example 2)."""
+        payload = self.base_payload.copy()
+        payload['inputs']['days_in_current_year'] = 120
+        payload['inputs']['days_each_of_prev_5_years'] = [200, 180, 150, 200, 220] # sum = 950
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['result']['details']['status'], 'Resident')
+        self.assertIn('physical presence test', data['result']['details']['reasoning'])
+
+    def test_physical_presence_fail_total_days(self):
+        """Test a user who fails the 915-day total (user's example 1)."""
+        payload = self.base_payload.copy()
+        payload['inputs']['days_in_current_year'] = 120
+        payload['inputs']['days_each_of_prev_5_years'] = [150, 100, 95, 120, 130] # sum = 595
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['result']['details']['status'], 'Non-Resident')
+        self.assertIn('Total days in past 5 years >= 915: Fail', data['result']['details']['reasoning'])
+
+    def test_physical_presence_fail_one_year(self):
+        """Test a user who fails because one of the preceding years is < 91 days."""
+        payload = self.base_payload.copy()
+        payload['inputs']['days_in_current_year'] = 100
+        payload['inputs']['days_each_of_prev_5_years'] = [200, 200, 80, 200, 200] # sum = 880
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['result']['details']['status'], 'Non-Resident')
+        self.assertIn('Days in each of past 5 years >= 91: Fail', data['result']['details']['reasoning'])
+
+    def test_exit_rule_applies(self):
+        """Test the 330-day exit rule for a user who was physically present."""
+        payload = self.base_payload.copy()
+        payload['inputs']['days_in_current_year'] = 120
+        payload['inputs']['days_each_of_prev_5_years'] = [200, 180, 150, 200, 220] # Pass presence test
+        payload['inputs']['days_continuously_absent'] = 331
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['result']['details']['status'], 'Non-Resident')
+        self.assertIn('continuously outside of South Africa', data['result']['details']['reasoning'])
+
+    def test_input_validation_error(self):
+        """Test that invalid input returns a proper error."""
+        payload = self.base_payload.copy()
+        payload['inputs']['days_each_of_prev_5_years'] = [100, 100] # Invalid list length
+
+        response = self.app.post('/compliance/run', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['result']['status'], 'error')
+        self.assertIn('Input data is invalid', data['result']['summary'])
+        # Check for Pydantic v2 error message for list length
+        self.assertTrue(any('5 items' in e['msg'] for e in data['result']['details']))

--- a/wordpress/wp-content/themes/client-theme/template-residency-planner.php
+++ b/wordpress/wp-content/themes/client-theme/template-residency-planner.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Template Name: International Tax Residency Planner
+ *
+ * This template provides a tool to help users determine their
+ * South African tax residency status.
+ */
+
+get_header();
+?>
+
+<div id="primary" class="content-area">
+    <main id="main" class="site-main">
+        <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+            <header class="entry-header">
+                <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+            </header>
+
+            <div class="entry-content">
+                <p>This tool helps you determine your South African tax residency status by guiding you through the official tests. Your tax residency status determines whether you are taxed on your worldwide income or only on income from a South African source.</p>
+
+                <div class="planner-container card">
+                    <!-- Step 1: Ordinary Residence -->
+                    <div id="step-1" class="planner-step">
+                        <h3>Step 1: Ordinary Residence Test</h3>
+                        <p>This test is about where your "real home" is. Answer the following questions about your personal and economic ties to South Africa.</p>
+                        <form id="ordinary-residence-form">
+                            <div class="form-group-checkbox">
+                                <input type="checkbox" id="has_permanent_home" name="has_permanent_home">
+                                <label for="has_permanent_home">Do you have a permanent home available in South Africa?</label>
+                            </div>
+                            <div class="form-group-checkbox">
+                                <input type="checkbox" id="has_family_ties" name="has_family_ties">
+                                <label for="has_family_ties">Are your immediate family members (e.g., spouse, children) primarily based in South Africa?</label>
+                            </div>
+                             <div class="form-group-checkbox">
+                                <input type="checkbox" id="has_economic_ties" name="has_economic_ties">
+                                <label for="has_economic_ties">Are your main economic interests (e.g., businesses, assets) located in South Africa?</label>
+                            </div>
+                            <div class="form-group-checkbox">
+                                <input type="checkbox" id="intends_to_return" name="intends_to_return">
+                                <label for="intends_to_return">Do you intend to return to South Africa as your permanent home?</label>
+                            </div>
+                            <div class="form-group">
+                                <button type="button" id="check-ordinary-residence" class="button">Check Ordinary Residence</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step 2: Physical Presence -->
+                    <div id="step-2" class="planner-step" style="display: none;">
+                        <h3>Step 2: Physical Presence Test</h3>
+                        <p>Since you may not be ordinarily resident, we need to check the number of days you have been physically present in South Africa.</p>
+                        <form id="physical-presence-form">
+                            <div class="form-group">
+                                <label for="days_in_current_year">Days in SA (Current Tax Year)</label>
+                                <input type="number" id="days_in_current_year" required value="100">
+                            </div>
+                            <p>Days in SA for each of the <strong>5 preceding</strong> tax years:</p>
+                            <div class="form-group-grid">
+                                <input type="number" id="prev_year_1" placeholder="Year -1" required value="100">
+                                <input type="number" id="prev_year_2" placeholder="Year -2" required value="100">
+                                <input type="number" id="prev_year_3" placeholder="Year -3" required value="100">
+                                <input type="number" id="prev_year_4" placeholder="Year -4" required value="100">
+                                <input type="number" id="prev_year_5" placeholder="Year -5" required value="100">
+                            </div>
+                             <div class="form-group">
+                                <button type="submit" class="button button-primary">Determine My Residency</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step 3: Exit Rule (Optional) -->
+                    <div id="step-3" class="planner-step" style="display: none;">
+                        <h4>Already a resident and think you've left? (Exit Rule)</h4>
+                         <div class="form-group">
+                            <label for="days_continuously_absent">Days continuously outside SA (optional)</label>
+                            <input type="number" id="days_continuously_absent" placeholder="e.g., 331">
+                            <small>If you were resident via the Physical Presence Test, spending over 330 continuous days abroad may cease your residency.</small>
+                        </div>
+                    </div>
+
+                    <!-- Results -->
+                    <div class="calculator-results" id="results-container" style="display: none;">
+                        <h3>Your Tax Residency Status</h3>
+                        <div id="loader" style="display: none;">Calculating...</div>
+                        <div id="results-content"></div>
+                    </div>
+                </div>
+
+            </div><!-- .entry-content -->
+        </article><!-- #post-<?php the_ID(); ?> -->
+    </main><!-- #main -->
+</div><!-- #primary -->
+
+<style>
+.planner-container.card { border: 1px solid #ddd; padding: 1.5em; border-radius: 8px; background-color: #f9f9f9; margin-top: 1em; }
+.planner-step { border-bottom: 1px solid #e0e0e0; padding-bottom: 1.5em; margin-bottom: 1.5em; }
+.planner-step:last-child { border-bottom: none; }
+.form-group { margin-bottom: 1em; }
+.form-group-checkbox { display: flex; align-items: center; margin-bottom: 0.8em; }
+.form-group-checkbox input { margin-right: 10px; width: auto; }
+.form-group-checkbox label { margin-bottom: 0; font-weight: normal; }
+.form-group-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(80px, 1fr)); gap: 10px; }
+.form-group label, .form-group p { display: block; margin-bottom: 0.5em; font-weight: bold; }
+.form-group input, .form-group select { width: 100%; padding: 0.75em; border: 1px solid #ccc; border-radius: 4px; }
+.button { padding: 10px 15px; border: 1px solid #ccc; background-color: #f0f0f0; border-radius: 4px; cursor: pointer; }
+.button-primary { background-color: #0073aa; color: white; border-color: #0073aa; }
+.calculator-results { margin-top: 1em; padding-top: 1.5em; border-top: 2px solid #0073aa; }
+.result-box { padding: 1em; border-radius: 5px; }
+.result-box.resident { background-color: #fff5f5; border: 1px solid #e53e3e; }
+.result-box.non-resident { background-color: #f0fff4; border: 1px solid #38a169; }
+.result-box h4 { margin-top: 0; }
+.result-box .reasoning { font-style: italic; color: #555; margin: 0.5em 0; }
+.result-box .advice { margin-top: 1em; padding-top: 1em; border-top: 1px solid #ddd; font-weight: bold; }
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const step1 = document.getElementById('step-1');
+    const step2 = document.getElementById('step-2');
+    const step3 = document.getElementById('step-3'); // Optional exit rule inputs
+    const checkOrdResidenceBtn = document.getElementById('check-ordinary-residence');
+    const presenceForm = document.getElementById('physical-presence-form');
+
+    const resultsContainer = document.getElementById('results-container');
+    const loader = document.getElementById('loader');
+    const resultsContent = document.getElementById('results-content');
+
+    let ordinaryResidenceFlags = {};
+
+    checkOrdResidenceBtn.addEventListener('click', function() {
+        const ordForm = new FormData(document.getElementById('ordinary-residence-form'));
+        ordinaryResidenceFlags = {
+            has_permanent_home: ordForm.has('has_permanent_home'),
+            has_family_ties: ordForm.has('has_family_ties'),
+            has_economic_ties: ordForm.has('has_economic_ties'),
+            intends_to_return: ordForm.has('intends_to_return')
+        };
+
+        // Simple heuristic: if 3 or more are true, they are likely resident. Let's send to API anyway.
+        const trueCount = Object.values(ordinaryResidenceFlags).filter(Boolean).length;
+        if (trueCount >= 3) {
+            // We can pre-emptively run the calculation
+             runFullCalculation();
+        } else {
+            // Otherwise, move to next step
+            step1.style.display = 'none';
+            step2.style.display = 'block';
+            step3.style.display = 'block';
+        }
+    });
+
+    presenceForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+        runFullCalculation();
+    });
+
+    function runFullCalculation() {
+        loader.style.display = 'block';
+        resultsContainer.style.display = 'block';
+        resultsContent.innerHTML = '';
+
+        const presenceData = new FormData(presenceForm);
+        const exitDays = document.getElementById('days_continuously_absent').value;
+
+        const inputs = {
+            ordinary_residence_flags: ordinaryResidenceFlags,
+            days_in_current_year: parseInt(document.getElementById('days_in_current_year').value) || 0,
+            days_each_of_prev_5_years: [
+                parseInt(document.getElementById('prev_year_1').value) || 0,
+                parseInt(document.getElementById('prev_year_2').value) || 0,
+                parseInt(document.getElementById('prev_year_3').value) || 0,
+                parseInt(document.getElementById('prev_year_4').value) || 0,
+                parseInt(document.getElementById('prev_year_5').value) || 0,
+            ],
+            days_continuously_absent: exitDays ? parseInt(exitDays) : null,
+        };
+
+        const apiUrl = '/api/eng-compliance/compliance/run';
+
+        fetch(apiUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                module_id: 'residency_planner',
+                inputs: inputs
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            loader.style.display = 'none';
+            if (data.ok && data.result.status === 'completed') {
+                displayResults(data.result.details);
+            } else {
+                let errorSummary = (data.result && data.result.summary) ? data.result.summary : 'An unknown error occurred.';
+                displayError(errorSummary);
+            }
+        })
+        .catch(error => {
+            loader.style.display = 'none';
+            displayError('Failed to connect to the calculation service.');
+            console.error('Error:', error);
+        });
+    }
+
+    function displayError(message) {
+        resultsContent.innerHTML = `<div class="result-box resident"><h4>Error</h4><p>${message}</p></div>`;
+    }
+
+    function displayResults(details) {
+        const { status, reasoning, advice } = details;
+        const statusClass = status.toLowerCase().replace(' ', '-');
+        resultsContent.innerHTML = `
+            <div class="result-box ${statusClass}">
+                <h4>Status: ${status}</h4>
+                <p class="reasoning">${reasoning}</p>
+                <div class="advice">${advice}</div>
+            </div>
+        `;
+    }
+});
+</script>
+
+<?php
+get_footer();
+?>


### PR DESCRIPTION
The backend implementation adds a new `residency_planner` module to the `eng-compliance` service. It follows the specified decision-tree logic (Ordinary Residence, Physical Presence, Exit Rule) to determine a user's tax residency status. The module is exposed via the `/compliance/run` API endpoint and is controlled by the `RESIDENCY_PLANNER_ENABLED` feature flag. The implementation is covered by a comprehensive suite of unit tests.

The frontend consists of a new WordPress page template (`template-residency-planner.php`) that provides a multi-step questionnaire UI. This guides the user through the complex residency questions and uses JavaScript to interact with the backend API and display the final determination.

The test suite has also been made more robust by ensuring all feature flags are enabled consistently during test runs.