### PR TITLE
fix(theme): Resolve "Method Not Allowed" error on live preview

### DIFF
--- a/assetarc-theme/functions.php
+++ b/assetarc-theme/functions.php
@@ -102,7 +102,11 @@ require get_template_directory() . '/inc/token-request-handler.php';
 require get_template_directory() . '/inc/course-handler.php';
 
 // Load any optional review routing logic
-require get_template_directory() . '/parts/review-flag-router.php';
+function assetarc_handle_flag_review_request() {
+    require get_template_directory() . '/parts/review-flag-router.php';
+}
+add_action('admin_post_nopriv_assetarc_flag_review', 'assetarc_handle_flag_review_request');
+add_action('admin_post_assetarc_flag_review', 'assetarc_handle_flag_review_request');
 
 // Register Custom Post Types for Education Hub
 function assetarc_register_post_types() {


### PR DESCRIPTION
The `review-flag-router.php` script was being loaded directly in `functions.php`, causing it to execute on every page load. This script contained logic to reject non-POST requests with a 405 "Method Not Allowed" error.

This prevented the theme customizer's live preview, which uses a GET request, from loading correctly.

The fix wraps the inclusion of `review-flag-router.php` within a function that is hooked to the `admin_post` action. This ensures the router logic is only executed when a specific form is submitted, which is the correct WordPress practice, and no longer interferes with other admin functionality.