### PR TITLE
feat: Add targeted prompts for Phase 2 planners

### DIFF
--- a/prompts/P2_RES_EXIT_RULE.txt
+++ b/prompts/P2_RES_EXIT_RULE.txt
@@ -1,0 +1,56 @@
+You are an expert in South African tax law, specializing in the rules for tax residency. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent an individual who **was previously a tax resident** via the Physical Presence Test, but who has now **ceased to be a resident** by remaining outside of South Africa for a continuous period of at least 331 days.
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "ordinary_residence_flags": {
+    "has_permanent_home": false,
+    "has_family_ties": false,
+    "has_economic_ties": "boolean",
+    "intends_to_return": false
+  },
+  "days_in_current_year": "number",
+  "days_each_of_prev_5_years": ["number", "number", "number", "number", "number"],
+  "days_continuously_absent": "number"
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a "Non-Resident" determination due to the exit rule.
+
+```json
+{
+  "status": "Non-Resident",
+  "reasoning": "You are now considered a non-resident for tax purposes. Although you may have been a resident previously, you have remained outside of South Africa for a continuous period of more than 330 days, which ceases your residency from the day you left.",
+  "advice": "Your tax residency ceased on the first day of your continuous absence. You should consult a tax professional to manage your final tax return as a resident and understand your new obligations as a non-resident."
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_RES_EXIT_RULE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** `output.status` must always be `"Non-Resident"`. All ordinary residence flags should be `false`.
+2.  **Exit Rule Condition:** The key is the `days_continuously_absent` field. Its value MUST be greater than 330.
+3.  **Prior Residency:** The day counts for previous years should be high enough that the person *would have been* a resident via the physical presence test before their long absence.
+4.  **Rationale:** The `meta.rationale` must clearly explain that residency was ceased under the specific >330 day rule for individuals who are not ordinarily resident.
+
+**Example Flashcard:**
+
+{"input": {"ordinary_residence_flags": {"has_permanent_home": false, "has_family_ties": false, "has_economic_ties": true, "intends_to_return": false}, "days_in_current_year": 0, "days_each_of_prev_5_years": [150, 200, 180, 250, 150], "days_continuously_absent": 365}, "output": {"status": "Non-Resident", "reasoning": "You are now considered a non-resident for tax purposes. Although you may have been a resident previously, you have remained outside of South Africa for a continuous period of more than 330 days, which ceases your residency from the day you left.", "advice": "Your tax residency ceased on the first day of your continuous absence. You should consult a tax professional to manage your final tax return as a resident and understand your new obligations as a non-resident."}, "meta": {"rationale": "The individual, who was previously resident via the physical presence test, has ceased to be a resident. They have been continuously absent from SA for more than 330 days (365), triggering the exit rule. Their residency is deemed to have ceased on the day they left SA.", "source_prompt_id": "P2_RES_EXIT_RULE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_RES_NON_RESIDENT.txt
+++ b/prompts/P2_RES_NON_RESIDENT.txt
@@ -1,0 +1,58 @@
+You are an expert in South African tax law, specializing in the rules for tax residency. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent an individual who is clearly a **Non-Resident** for tax purposes, failing both the Ordinary Residence test and the Physical Presence Test.
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "ordinary_residence_flags": {
+    "has_permanent_home": false,
+    "has_family_ties": false,
+    "has_economic_ties": false,
+    "intends_to_return": false
+  },
+  "days_in_current_year": "number",
+  "days_each_of_prev_5_years": ["number", "number", "number", "number", "number"],
+  "days_continuously_absent": "number"
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a "Non-Resident" determination.
+
+```json
+{
+  "status": "Non-Resident",
+  "reasoning": "You are considered a non-resident for tax purposes because you do not meet the criteria for the ordinary residence test or the physical presence test.",
+  "advice": "As a non-resident, you are typically only liable for tax on income from a South African source. Please consult a tax professional for specific advice."
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_RES_NON_RESIDENT"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** `output.status` must always be `"Non-Resident"`. All flags in `input.ordinary_residence_flags` must be `false`.
+2.  **Failing the Physical Presence Test:** The day counts MUST fail at least one part of the test. Create variety by failing different parts:
+    *   Make `days_in_current_year` less than 92.
+    *   Make one of the `days_each_of_prev_5_years` less than 92.
+    *   Keep all individual year day counts high, but ensure the SUM of the 5 previous years is less than 915.
+3.  **Rationale:** The `meta.rationale` must clearly state that the individual is not ordinarily resident and fails the physical presence test, ideally mentioning which part of the test they failed.
+
+**Example Flashcard:**
+
+{"input": {"ordinary_residence_flags": {"has_permanent_home": false, "has_family_ties": false, "has_economic_ties": false, "intends_to_return": false}, "days_in_current_year": 50, "days_each_of_prev_5_years": [100, 100, 100, 100, 100], "days_continuously_absent": 0}, "output": {"status": "Non-Resident", "reasoning": "You are considered a non-resident for tax purposes because you do not meet the criteria for the ordinary residence test or the physical presence test.", "advice": "As a non-resident, you are typically only liable for tax on income from a South African source. Please consult a tax professional for specific advice."}, "meta": {"rationale": "The individual is not ordinarily resident. They also fail the physical presence test because they spent fewer than 92 days in the current tax year (50). Therefore, they are a non-resident.", "source_prompt_id": "P2_RES_NON_RESIDENT"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_RES_ORD_RESIDENT.txt
+++ b/prompts/P2_RES_ORD_RESIDENT.txt
@@ -1,0 +1,55 @@
+You are an expert in South African tax law, specializing in the rules for tax residency. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent an individual who is clearly a **tax resident** of South Africa based on the **Ordinary Residence test**.
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "ordinary_residence_flags": {
+    "has_permanent_home": true,
+    "has_family_ties": "boolean",
+    "has_economic_ties": "boolean",
+    "intends_to_return": true
+  },
+  "days_in_current_year": "number",
+  "days_each_of_prev_5_years": ["number", "number", "number", "number", "number"],
+  "days_continuously_absent": "number"
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a "Resident" determination.
+
+```json
+{
+  "status": "Resident",
+  "reasoning": "You are considered a resident for tax purposes because your circumstances suggest that South Africa is your true home (the place you would naturally return to), making you 'ordinarily resident'.",
+  "advice": "As a tax resident, you are typically liable for tax on your worldwide income. You should consult a tax professional to understand your specific obligations."
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_RES_ORD_RESIDENT"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** `output.status` must always be `"Resident"`.
+2.  **Ordinary Residence Focus:** The `input.ordinary_residence_flags` must contain at least two `true` values, including `has_permanent_home` or `intends_to_return`. This ensures the individual is clearly ordinarily resident. The physical presence test data can be ignored or have low values, as it should not be the deciding factor.
+3.  **Rationale:** The `meta.rationale` must clearly explain that the individual is ordinarily resident and why. For example: "The individual is deemed ordinarily resident because they have a permanent home available in SA and their immediate family resides there. These strong ties indicate SA is their real home, so the physical presence test is not the determining factor."
+
+**Example Flashcard:**
+
+{"input": {"ordinary_residence_flags": {"has_permanent_home": true, "has_family_ties": true, "has_economic_ties": false, "intends_to_return": true}, "days_in_current_year": 20, "days_each_of_prev_5_years": [30, 50, 15, 60, 40], "days_continuously_absent": 0}, "output": {"status": "Resident", "reasoning": "You are considered a resident for tax purposes because your circumstances suggest that South Africa is your true home (the place you would naturally return to), making you 'ordinarily resident'.", "advice": "As a tax resident, you are typically liable for tax on your worldwide income. You should consult a tax professional to understand your specific obligations."}, "meta": {"rationale": "The individual is deemed ordinarily resident. The presence of a permanent home, family ties, and a clear intention to return make South Africa their true home. The low number of days spent in the country is irrelevant for this test.", "source_prompt_id": "P2_RES_ORD_RESIDENT"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_RES_PHYS_PRES_RESIDENT.txt
+++ b/prompts/P2_RES_PHYS_PRES_RESIDENT.txt
@@ -1,0 +1,58 @@
+You are an expert in South African tax law, specializing in the rules for tax residency. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent an individual who is **NOT ordinarily resident**, but **IS a tax resident** of South Africa because they meet the requirements of the **Physical Presence Test**.
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "ordinary_residence_flags": {
+    "has_permanent_home": false,
+    "has_family_ties": false,
+    "has_economic_ties": "boolean",
+    "intends_to_return": false
+  },
+  "days_in_current_year": "number",
+  "days_each_of_prev_5_years": ["number", "number", "number", "number", "number"],
+  "days_continuously_absent": "number"
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a "Resident" determination.
+
+```json
+{
+  "status": "Resident",
+  "reasoning": "You are considered a resident for tax purposes because you meet the requirements of the physical presence test.",
+  "advice": "As a tax resident, you are typically liable for tax on your worldwide income. You should consult a tax professional to understand your specific obligations."
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_RES_PHYS_PRES_RESIDENT"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** `output.status` must always be `"Resident"`. `input.ordinary_residence_flags` should have `false` for `has_permanent_home` and `intends_to_return`.
+2.  **Physical Presence Test:** The day counts MUST meet all three parts of the test:
+    *   `days_in_current_year` must be greater than 91.
+    *   Each of the 5 values in `days_each_of_prev_5_years` must be greater than 91.
+    *   The SUM of the 5 values in `days_each_of_prev_5_years` must be greater than 915.
+3.  **Rationale:** The `meta.rationale` must clearly state that the individual is resident via the physical presence test, and should ideally mention the day count thresholds being met.
+
+**Example Flashcard:**
+
+{"input": {"ordinary_residence_flags": {"has_permanent_home": false, "has_family_ties": false, "has_economic_ties": true, "intends_to_return": false}, "days_in_current_year": 120, "days_each_of_prev_5_years": [150, 200, 180, 250, 150], "days_continuously_absent": 10}, "output": {"status": "Resident", "reasoning": "You are considered a resident for tax purposes because you meet the requirements of the physical presence test.", "advice": "As a tax resident, you are typically liable for tax on your worldwide income. You should consult a tax professional to understand your specific obligations."}, "meta": {"rationale": "The individual is not ordinarily resident. However, they meet all three requirements of the physical presence test: over 91 days in the current year (120), over 91 days in each of the preceding 5 years, and a total of 930 days in the preceding 5 years (which is over the 915-day threshold). Therefore, they are deemed a resident.", "source_prompt_id": "P2_RES_PHYS_PRES_RESIDENT"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S42_ELIGIBLE.txt
+++ b/prompts/P2_ROLL_S42_ELIGIBLE.txt
@@ -1,0 +1,64 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **ELIGIBLE** for relief under **Section 42** of the Income Tax Act (Asset-for-Share transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s42",
+  "taxpayer_type": "string",
+  "transferor_residency": "SA",
+  "transferee_residency": "SA",
+  "consideration": { "shares_issued": true, "cash_boot": "number", "debt_assumed": "number" },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "continuity_flags": { "nature_retained": true },
+  "timing_flags": { "earmarked_disposal_months": null },
+  "group_relationship": {}, "unbundling_details": {}, "liquidation_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a successful eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": true,
+    "failed_reasons": [],
+    "warnings": ["string"]
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": "number",
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": "number",
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S42_ELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s42"`. The `input.consideration.shares_issued` must always be `true`. `input.transferor_residency` and `input.transferee_residency` must be `"SA"`. `output.eligibility.eligible` must always be `true` and `output.eligibility.failed_reasons` must be an empty list `[]`.
+2.  **Logical Consistency:** The financial numbers in `output.tax_comparison` must be arithmetically plausible based on the `input.asset_profile`. The `net_deferral_benefit` should be greater than zero.
+3.  **Rationale:** The `meta.rationale` must explain *why* the scenario is eligible for s42 relief, referencing the key conditions being met (e.g., "The transaction is eligible for s42 relief as the transferor is an SA resident who transferred an asset to another SA resident company in exchange for equity shares.").
+
+**Example Flashcard:**
+
+{"input": {"section": "s42", "taxpayer_type": "company", "transferor_residency": "SA", "transferee_residency": "SA", "consideration": {"shares_issued": true, "cash_boot": 0, "debt_assumed": 0}, "asset_profile": {"type": "capital", "market_value": 10000000, "base_cost": 5000000}, "continuity_flags": {"nature_retained": true}, "timing_flags": {"earmarked_disposal_months": null}, "group_relationship": {}, "unbundling_details": {}, "liquidation_details": {}}, "output": {"eligibility": {"eligible": true, "failed_reasons": [], "warnings": []}, "tax_comparison": {"cgt_no_relief": 900000, "cgt_with_relief": 0, "rolled_base_cost_to_acquirer": 5000000, "net_deferral_benefit": 900000, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction qualifies for Section 42 relief because an SA resident company transferred an asset to another SA resident company solely in exchange for equity shares, meeting the core requirements.", "source_prompt_id": "P2_ROLL_S42_ELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S42_INELIGIBLE.txt
+++ b/prompts/P2_ROLL_S42_INELIGIBLE.txt
@@ -1,0 +1,69 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **INELIGIBLE** for relief under **Section 42** of the Income Tax Act (Asset-for-Share transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s42",
+  "taxpayer_type": "string",
+  "transferor_residency": "string",
+  "transferee_residency": "string",
+  "consideration": { "shares_issued": "boolean", "cash_boot": "number", "debt_assumed": "number" },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "continuity_flags": { "nature_retained": "boolean" },
+  "timing_flags": { "earmarked_disposal_months": "number" },
+  "group_relationship": {}, "unbundling_details": {}, "liquidation_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a FAILED eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": false,
+    "failed_reasons": ["string"],
+    "warnings": []
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": "number",
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": 0,
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S42_INELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s42"`. The `output.eligibility.eligible` must always be `false` and `output.eligibility.failed_reasons` must contain at least one reason. The `output.tax_comparison.net_deferral_benefit` must be `0`.
+2.  **Vary Failure Reasons:** Create a diverse set of ineligible scenarios. Focus on different reasons for failure:
+    *   The `transferor_residency` is `"non-SA"`.
+    *   The `transferee_residency` is `"non-SA"`.
+    *   The `consideration.shares_issued` is `false`.
+    *   The `continuity_flags.nature_retained` is `false`.
+3.  **Logical Consistency:** The `output.eligibility.failed_reasons` must accurately reflect the reason for failure in the `input`.
+4.  **Rationale:** The `meta.rationale` must clearly explain *why* the scenario is ineligible, referencing the specific condition that was not met.
+
+**Example Flashcard:**
+
+{"input": {"section": "s42", "taxpayer_type": "company", "transferor_residency": "non-SA", "transferee_residency": "SA", "consideration": {"shares_issued": true, "cash_boot": 0, "debt_assumed": 0}, "asset_profile": {"type": "capital", "market_value": 8000000, "base_cost": 3000000}, "continuity_flags": {"nature_retained": true}, "timing_flags": {"earmarked_disposal_months": null}, "group_relationship": {}, "unbundling_details": {}, "liquidation_details": {}}, "output": {"eligibility": {"eligible": false, "failed_reasons": ["The transferor must be a resident of South Africa."], "warnings": []}, "tax_comparison": {"cgt_no_relief": 900000, "cgt_with_relief": 900000, "rolled_base_cost_to_acquirer": 3000000, "net_deferral_benefit": 0, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction is ineligible for Section 42 relief because the transferor of the asset is not a resident of South Africa, which is a mandatory requirement for the provision to apply.", "source_prompt_id": "P2_ROLL_S42_INELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S45_ELIGIBLE.txt
+++ b/prompts/P2_ROLL_S45_ELIGIBLE.txt
@@ -1,0 +1,63 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **ELIGIBLE** for relief under **Section 45** of the Income Tax Act (Intra-Group transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s45",
+  "taxpayer_type": "string",
+  "transferor_residency": "SA",
+  "transferee_residency": "SA",
+  "group_relationship": { "same_group": true, "percentage": "number" },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "consideration": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}, "liquidation_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a successful eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": true,
+    "failed_reasons": [],
+    "warnings": ["string"]
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": "number",
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": "number",
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S45_ELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s45"`. Both `transferor_residency` and `transferee_residency` must be `"SA"`. `input.group_relationship.same_group` must be `true`. The `input.group_relationship.percentage` must be a number >= 70.
+2.  **Eligibility:** `output.eligibility.eligible` must always be `true` and `output.eligibility.failed_reasons` must be an empty list `[]`.
+3.  **Logical Consistency:** The financial numbers in `output.tax_comparison` must be arithmetically plausible. `net_deferral_benefit` should be greater than zero.
+4.  **Rationale:** The `meta.rationale` must explain *why* the scenario is eligible for s45 relief, referencing the key conditions being met (e.g., "The transaction is eligible for s45 relief as it occurs between two SA resident companies that form part of the same group of companies (with >= 70% shareholding).").
+
+**Example Flashcard:**
+
+{"input": {"section": "s45", "taxpayer_type": "company", "transferor_residency": "SA", "transferee_residency": "SA", "group_relationship": {"same_group": true, "percentage": 80}, "asset_profile": {"type": "capital", "market_value": 2000000, "base_cost": 1000000}, "consideration": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}, "liquidation_details": {}}, "output": {"eligibility": {"eligible": true, "failed_reasons": [], "warnings": []}, "tax_comparison": {"cgt_no_relief": 180000, "cgt_with_relief": 0, "rolled_base_cost_to_acquirer": 1000000, "net_deferral_benefit": 180000, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction qualifies for Section 45 relief because it's an intra-group transaction between two SA resident companies where the shareholding (80%) meets the >= 70% threshold.", "source_prompt_id": "P2_ROLL_S45_ELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S45_INELIGIBLE.txt
+++ b/prompts/P2_ROLL_S45_INELIGIBLE.txt
@@ -1,0 +1,65 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **INELIGIBLE** for relief under **Section 45** of the Income Tax Act (Intra-Group transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s45",
+  "taxpayer_type": "string",
+  "transferor_residency": "SA",
+  "transferee_residency": "SA",
+  "group_relationship": { "same_group": "boolean", "percentage": "number" },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "consideration": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}, "liquidation_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a FAILED eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": false,
+    "failed_reasons": ["string"],
+    "warnings": []
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": "number",
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": 0,
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S45_INELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s45"`. The `output.eligibility.eligible` must always be `false`. The `output.tax_comparison.net_deferral_benefit` must be `0`.
+2.  **Vary Failure Reasons:** Create a diverse set of ineligible scenarios. Focus on the main failure reason for s45: the group relationship.
+    *   Set `input.group_relationship.same_group` to `false`.
+    *   Set `input.group_relationship.percentage` to a value less than 70.
+3.  **Logical Consistency:** The `output.eligibility.failed_reasons` must accurately reflect the reason for failure in the `input`.
+4.  **Rationale:** The `meta.rationale` must clearly explain *why* the scenario is ineligible, referencing the group relationship requirement.
+
+**Example Flashcard:**
+
+{"input": {"section": "s45", "taxpayer_type": "company", "transferor_residency": "SA", "transferee_residency": "SA", "group_relationship": {"same_group": true, "percentage": 65}, "asset_profile": {"type": "capital", "market_value": 3000000, "base_cost": 1500000}, "consideration": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}, "liquidation_details": {}}, "output": {"eligibility": {"eligible": false, "failed_reasons": ["The companies do not form part of the same group of companies as the shareholding percentage (65%) is less than the required 70% threshold."], "warnings": []}, "tax_comparison": {"cgt_no_relief": 270000, "cgt_with_relief": 270000, "rolled_base_cost_to_acquirer": 1500000, "net_deferral_benefit": 0, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction is ineligible for Section 45 relief because the required 70% shareholding for a 'group of companies' is not met. The 65% holding is insufficient.", "source_prompt_id": "P2_ROLL_S45_INELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S46_ELIGIBLE.txt
+++ b/prompts/P2_ROLL_S46_ELIGIBLE.txt
@@ -1,0 +1,62 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **ELIGIBLE** for relief under **Section 46** of the Income Tax Act (Unbundling transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s46",
+  "taxpayer_type": "string",
+  "transferor_residency": "SA",
+  "transferee_residency": "SA",
+  "unbundling_details": { "control_threshold_met": true },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "consideration": {}, "group_relationship": {}, "continuity_flags": {}, "timing_flags": {}, "liquidation_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a successful eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": true,
+    "failed_reasons": [],
+    "warnings": []
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": 0,
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": "number",
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S46_ELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s46"`. `input.unbundling_details.control_threshold_met` must be `true`. `output.eligibility.eligible` must always be `true`.
+2.  **Logical Consistency:** The financial numbers must be arithmetically plausible. `net_deferral_benefit` should be greater than zero.
+3.  **Rationale:** The `meta.rationale` must explain *why* the scenario is eligible for s46 relief, referencing the key conditions for unbundling transactions.
+
+**Example Flashcard:**
+
+{"input": {"section": "s46", "taxpayer_type": "company", "transferor_residency": "SA", "transferee_residency": "SA", "unbundling_details": {"control_threshold_met": true}, "asset_profile": {"type": "capital", "market_value": 50000000, "base_cost": 10000000}, "consideration": {}, "group_relationship": {}, "continuity_flags": {}, "timing_flags": {}, "liquidation_details": {}}, "output": {"eligibility": {"eligible": true, "failed_reasons": [], "warnings": []}, "tax_comparison": {"cgt_no_relief": 7200000, "cgt_with_relief": 0, "rolled_base_cost_to_acquirer": 10000000, "net_deferral_benefit": 7200000, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction qualifies for Section 46 relief as it is an unbundling transaction where the control threshold was met, allowing for the tax-neutral transfer of shares.", "source_prompt_id": "P2_ROLL_S46_ELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.

--- a/prompts/P2_ROLL_S47_ELIGIBLE.txt
+++ b/prompts/P2_ROLL_S47_ELIGIBLE.txt
@@ -1,0 +1,62 @@
+You are an expert in South African tax law, specifically corporate rollover relief provisions. Your task is to generate a high-quality dataset for training a specialized AI model.
+
+**Primary Objective:**
+Generate exactly 50 flashcards in NDJSON format. Each flashcard must represent a transaction that is **ELIGIBLE** for relief under **Section 47** of the Income Tax Act (Liquidation transactions).
+
+**Flashcard Schema:**
+Each JSON object must have three top-level keys: `input`, `output`, and `meta`.
+
+**1. Input Schema:**
+The `input` object must conform to the following structure.
+
+```json
+{
+  "section": "s47",
+  "taxpayer_type": "string",
+  "transferor_residency": "SA",
+  "transferee_residency": "SA",
+  "liquidation_details": { "steps_to_deregister_within_36m": true },
+  "asset_profile": { "type": "string", "market_value": "number", "base_cost": "number" },
+  "consideration": {}, "group_relationship": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}
+}
+```
+
+**2. Output Schema:**
+The `output` object must represent a successful eligibility check.
+
+```json
+{
+  "eligibility": {
+    "eligible": true,
+    "failed_reasons": [],
+    "warnings": []
+  },
+  "tax_comparison": {
+    "cgt_no_relief": "number",
+    "cgt_with_relief": 0,
+    "rolled_base_cost_to_acquirer": "number",
+    "net_deferral_benefit": "number",
+    "notes": ["string"]
+  }
+}
+```
+
+**3. Meta Schema:**
+
+```json
+{
+  "rationale": "string",
+  "source_prompt_id": "P2_ROLL_S47_ELIGIBLE"
+}
+```
+
+**Content Generation Constraints (Very Important):**
+1.  **Fixed Values:** The `input.section` must always be `"s47"`. `input.liquidation_details.steps_to_deregister_within_36m` must be `true`. `output.eligibility.eligible` must always be `true`.
+2.  **Logical Consistency:** The financial numbers must be arithmetically plausible. `net_deferral_benefit` should be greater than zero.
+3.  **Rationale:** The `meta.rationale` must explain *why* the scenario is eligible for s47 relief, referencing the key conditions for liquidation transactions (e.g., "The transaction qualifies for Section 47 relief as the liquidating company has taken the necessary steps to deregister within 36 months.").
+
+**Example Flashcard:**
+
+{"input": {"section": "s47", "taxpayer_type": "company", "transferor_residency": "SA", "transferee_residency": "SA", "liquidation_details": {"steps_to_deregister_within_36m": true}, "asset_profile": {"type": "capital", "market_value": 25000000, "base_cost": 15000000}, "consideration": {}, "group_relationship": {}, "continuity_flags": {}, "timing_flags": {}, "unbundling_details": {}}, "output": {"eligibility": {"eligible": true, "failed_reasons": [], "warnings": []}, "tax_comparison": {"cgt_no_relief": 1800000, "cgt_with_relief": 0, "rolled_base_cost_to_acquirer": 15000000, "net_deferral_benefit": 1800000, "notes": ["Calculation assumes a 18% CGT inclusion rate for companies and a 27% corporate income tax rate for 2024."]}}, "meta": {"rationale": "The transaction qualifies for Section 47 relief. The liquidating company is an SA resident, and has commenced the process of liquidation and deregistration which will be completed within the required 36-month period.", "source_prompt_id": "P2_ROLL_S47_ELIGIBLE"}}
+
+Now, please generate exactly 50 flashcards following these instructions.


### PR DESCRIPTION
This commit adds 10 new targeted prompt files to generate specific training data for the Phase 2 "Rollover Planner" and "Tax Residency Planner" AI modules.

This follows the strategy of having both broad, generative master prompts and narrow, targeted prompts to ensure a robust and comprehensive training dataset.

The new prompts cover:
- Eligible and ineligible scenarios for Section 42 and 45 of the Income Tax Act.
- Eligible scenarios for Section 46 and 47.
- Specific outcomes for the Tax Residency Planner, including resident by ordinary residence, resident by physical presence, non-resident, and cessation of residency via the exit rule.