### PR TITLE
feat: Add dedicated scripts for Phase 2 data generation

### DIFF
--- a/PHASE_2_GENERATION_GUIDE.md
+++ b/PHASE_2_GENERATION_GUIDE.md
@@ -1,0 +1,59 @@
+# Phase 2 Data Generation Guide
+
+This guide explains how to use the dedicated scripts to generate the training dataset for the Phase 2 AI models (Rollover Planner and Residency Planner).
+
+The Phase 2 generation process uses two new scripts:
+- `scripts/run_generation_phase2.sh`: A shell script to automate running all Phase 2 prompts.
+- `scripts/generate_flashcards_phase2.py`: A Python script that takes a single Phase 2 prompt and generates the corresponding flashcards.
+
+---
+
+## 1. How to Generate the Entire Phase 2 Dataset
+
+This is the recommended and simplest method. The `run_generation_phase2.sh` script will automatically find all `P2_*.txt` prompts in the `prompts/` directory, determine the correct schema to use, and run the generator for each one.
+
+**Steps:**
+
+1.  **Open your terminal** and make sure you are in the root directory of this repository.
+2.  **Ensure the script is executable.** If this is the first time you are running it, you may need to give it execute permissions:
+    ```bash
+    chmod +x scripts/run_generation_phase2.sh
+    ```
+3.  **Run the script:**
+    ```bash
+    ./scripts/run_generation_phase2.sh
+    ```
+
+The script will print its progress to the console. Once it's finished, you will find all the generated `_output.ndjson` files inside the `generated_data/` directory.
+
+---
+
+## 2. How to Run a Single Phase 2 Prompt (Advanced)
+
+If you only want to re-generate the data for a single prompt, you can call the Python script directly. This is useful for testing or debugging a specific prompt.
+
+The Python script requires three arguments:
+
+- `--prompt-file`: The path to the `P2_*.txt` prompt file you want to use.
+- `--output-file`: The path where you want to save the generated `.ndjson` file.
+- `--schema-type`: This is crucial. You must specify which validation schema to use. The valid options are `rollover` or `residency`.
+
+**Example for a Rollover prompt:**
+
+```bash
+python3 scripts/generate_flashcards_phase2.py \
+    --prompt-file "prompts/P2_ROLL_S42_ELIGIBLE.txt" \
+    --output-file "generated_data/P2_ROLL_S42_ELIGIBLE_output.ndjson" \
+    --schema-type "rollover"
+```
+
+**Example for a Residency prompt:**
+
+```bash
+python3 scripts/generate_flashcards_phase2.py \
+    --prompt-file "prompts/P2_RES_ORD_RESIDENT.txt" \
+    --output-file "generated_data/P2_RES_ORD_RESIDENT_output.ndjson" \
+    --schema-type "residency"
+```
+
+**Note:** You must have your `OPENAI_API_KEY` configured for the script to work. The script will attempt to fetch it from the project's secrets manager.

--- a/scripts/generate_flashcards_phase2.py
+++ b/scripts/generate_flashcards_phase2.py
@@ -1,0 +1,195 @@
+# scripts/generate_flashcards_phase2.py
+import os
+import sys
+import json
+import argparse
+import openai
+import jsonschema
+
+# Add the project root to the Python path to allow importing from 'common'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from common.secrets import get_secret
+
+# --- 1. Define the JSON Schemas for Phase 2 ---
+
+ROLLOVER_SCHEMA = {
+  "type":"object",
+  "required":["input","output","meta"],
+  "properties":{
+    "input":{
+      "type":"object",
+      "required":["section","asset_profile"],
+      "properties":{
+        "section": {"type": "string", "enum": ["s42", "s45", "s46", "s47"]},
+        "taxpayer_type": {"type": "string"},
+        "transferor_residency": {"type": "string"},
+        "transferee_residency": {"type": "string"},
+        "group_relationship": {"type": "object"},
+        "consideration": {"type": "object"},
+        "asset_profile": {"type": "object"},
+        "continuity_flags": {"type": "object"},
+        "timing_flags": {"type": "object"},
+        "unbundling_details": {"type": "object"},
+        "liquidation_details": {"type": "object"}
+      }
+    },
+    "output":{
+      "type":"object",
+      "required":["eligibility","tax_comparison"],
+      "properties":{
+        "eligibility": {"type": "object"},
+        "tax_comparison": {"type": "object"}
+      }
+    },
+    "meta":{
+      "type":"object",
+      "required":["rationale","source_prompt_id"],
+      "properties":{
+        "rationale": {"type": "string"},
+        "source_prompt_id": {"type": "string"}
+      }
+    }
+  }
+}
+
+RESIDENCY_SCHEMA = {
+  "type":"object",
+  "required":["input","output","meta"],
+  "properties":{
+    "input":{
+      "type":"object",
+      "required":["ordinary_residence_flags","days_in_current_year","days_each_of_prev_5_years"],
+      "properties":{
+        "ordinary_residence_flags": {"type": "object"},
+        "days_in_current_year": {"type": "number"},
+        "days_each_of_prev_5_years": {"type": "array", "items": {"type": "number"}},
+        "days_continuously_absent": {"type": ["number", "null"]}
+      }
+    },
+    "output":{
+      "type":"object",
+      "required":["status","reasoning","advice"],
+      "properties":{
+        "status": {"type": "string"},
+        "reasoning": {"type": "string"},
+        "advice": {"type": "string"}
+      }
+    },
+    "meta":{
+      "type":"object",
+      "required":["rationale","source_prompt_id"],
+      "properties":{
+        "rationale": {"type": "string"},
+        "source_prompt_id": {"type": "string"}
+      }
+    }
+  }
+}
+
+SCHEMA_MAP = {
+    "rollover": ROLLOVER_SCHEMA,
+    "residency": RESIDENCY_SCHEMA
+}
+
+# --- 2. Function to Call the LLM ---
+def generate_from_llm(prompt, api_key):
+    """
+    Calls the OpenAI API with a given prompt to generate flashcards.
+    """
+    print(f"INFO: Calling OpenAI API...")
+    try:
+        client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "You are a structured dataset generator. You only output valid, newline-delimited JSON (NDJSON) objects conforming to the user's requested schema. Do not output any other text, explanations, or markdown formatting."},
+                {"role": "user", "content": prompt}
+            ],
+            temperature=0.7,
+        )
+        print("INFO: OpenAI API call successful.")
+        return response.choices[0].message.content
+    except Exception as e:
+        print(f"ERROR: OpenAI API call failed: {e}")
+        return ""
+
+# --- 3. Function to Validate a Single Flashcard ---
+def validate_flashcard(flashcard_json, schema):
+    """
+    Validates a single JSON object against the provided schema.
+    """
+    try:
+        jsonschema.validate(instance=flashcard_json, schema=schema)
+        return True
+    except jsonschema.exceptions.ValidationError as e:
+        print(f"WARNING: Schema validation failed for flashcard. Reason: {e.message}")
+        return False
+    except Exception as e:
+        print(f"WARNING: An unexpected error occurred during validation: {e}")
+        return False
+
+# --- 4. Main Script Logic ---
+def main():
+    """
+    Main function to parse arguments, generate, validate, and save flashcards.
+    """
+    parser = argparse.ArgumentParser(description="Generate Phase 2 AI training flashcards using an LLM.")
+    parser.add_argument("--prompt-file", type=str, required=True, help="The path to the .txt file containing the prompt.")
+    parser.add_argument("--output-file", type=str, required=True, help="The path to save the output NDJSON file.")
+    parser.add_argument("--schema-type", type=str, required=True, choices=["rollover", "residency"], help="The type of schema to validate against ('rollover' or 'residency').")
+    parser.add_argument("--api-key", type=str, default=None, help="Optional: OpenAI API key. If not provided, it will be fetched from secrets.")
+
+    args = parser.parse_args()
+
+    # Select the schema
+    selected_schema = SCHEMA_MAP.get(args.schema_type)
+    if not selected_schema:
+        print(f"ERROR: Invalid schema type '{args.schema_type}'. Must be one of {list(SCHEMA_MAP.keys())}")
+        sys.exit(1)
+
+    print(f"INFO: Using schema type: {args.schema_type}")
+
+    # Read the prompt from the specified file
+    try:
+        with open(args.prompt_file, 'r') as f:
+            prompt_content = f.read()
+    except FileNotFoundError:
+        print(f"ERROR: The prompt file was not found at '{args.prompt_file}'. Please check the path.")
+        sys.exit(1)
+
+    # Create output directory if needed
+    output_dir = os.path.dirname(args.output_file)
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    api_key = args.api_key or get_secret("OPENAI_API_KEY")
+    if not api_key:
+        print("ERROR: OpenAI API key not found.")
+        sys.exit(1)
+
+    # Generate
+    raw_output = generate_from_llm(prompt_content, api_key)
+    if not raw_output:
+        print("ERROR: Received no output from the LLM. Exiting.")
+        sys.exit(1)
+
+    # Validate and Write
+    valid_count = 0
+    total_count = 0
+    with open(args.output_file, 'w') as f:
+        for line in raw_output.strip().split('\n'):
+            total_count += 1
+            try:
+                flashcard = json.loads(line)
+                if validate_flashcard(flashcard, selected_schema):
+                    f.write(json.dumps(flashcard) + '\n')
+                    valid_count += 1
+            except json.JSONDecodeError:
+                print(f"INFO: Skipping line with invalid JSON: {line}")
+
+    print("\n--- Generation Complete ---")
+    print(f"Total lines received from LLM: {total_count}")
+    print(f"Valid flashcards written: {valid_count}")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_generation_phase2.sh
+++ b/scripts/run_generation_phase2.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# A script to automate the generation of the entire Phase 2 training dataset.
+# It reads each P2 prompt file from the prompts/ directory and runs the
+# Python generation script for Phase 2, saving the output to the generated_data/ directory.
+
+# Ensure the script is run from the repository root
+if [ ! -d "scripts" ] || [ ! -d "prompts" ]; then
+    echo "ERROR: This script must be run from the root of the repository."
+    exit 1
+fi
+
+# Create the output directory if it doesn't exist
+mkdir -p generated_data
+
+echo "--- Starting AI Training Data Generation for Phase 2 ---"
+
+# Loop through all P2 prompt files in the prompts/ directory
+for prompt_file in prompts/P2_*.txt; do
+    if [ -f "$prompt_file" ]; then
+        # Extract the prompt ID from the filename (e.g., P2_ROLL_S42_ELIGIBLE)
+        prompt_id=$(basename "$prompt_file" .txt)
+        echo "INFO: Running generator for prompt: $prompt_id"
+
+        # Determine the schema type from the filename
+        schema_type=""
+        if [[ "$prompt_id" == *"_ROLL_"* ]]; then
+            schema_type="rollover"
+        elif [[ "$prompt_id" == *"_RES_"* ]]; then
+            schema_type="residency"
+        else
+            echo "WARNING: Could not determine schema type for $prompt_id. Skipping."
+            continue
+        fi
+
+        echo "INFO: Detected schema type: $schema_type"
+
+        # Define the output file path
+        output_file="generated_data/${prompt_id}_output.ndjson"
+
+        # Run the Phase 2 Python script
+        python3 scripts/generate_flashcards_phase2.py \
+            --prompt-file "$prompt_file" \
+            --output-file "$output_file" \
+            --schema-type "$schema_type"
+
+        echo "INFO: Generation for $prompt_id complete. Output saved to $output_file"
+        echo "-----------------------------------------------------"
+    fi
+done
+
+echo "--- All Phase 2 Data Generation Prompts Executed ---"


### PR DESCRIPTION
This commit introduces a new, separate set of scripts for generating the Phase 2 training dataset, as requested by the user to avoid modifying the working Phase 1 scripts.

- Created `scripts/generate_flashcards_phase2.py`, a new generator script containing the validation schemas for the Rollover and Residency planners. It accepts a `--schema-type` argument to select the correct schema.
- Created `scripts/run_generation_phase2.sh`, a new runner script that automates the generation of all Phase 2 data, intelligently passing the correct schema type to the python script based on the prompt filename.
- Added `PHASE_2_GENERATION_GUIDE.md` to provide clear instructions on how to use these new scripts.