### PR TITLE
fix: Refactor and standardize all P1 prompts

### DIFF
--- a/prompts/P1_ISTAX_01.txt
+++ b/prompts/P1_ISTAX_01.txt
@@ -1,20 +1,23 @@
-You are a structured dataset generator. Generate exactly 225 JSON flashcards (NDJSON) for tax_efficiency international use-cases.
+You are a structured dataset generator. Generate JSON flashcards as NDJSON (one JSON object per line, no extra text). Produce exactly 225 flashcards. Each JSON object MUST conform to the v1.0 flashcard schema provided to you: input, output, meta.
 
-Fixed fields:
+Constraints / fixed fields:
 - input.goals = ["tax_efficiency"]
-- input.jurisdiction ∈ {"uk","us","de","ae"}
 - output.recommended_structures = ["mu_ibc"]
 - meta.subsection = "intl_simple_tax"
 - meta.difficulty = "simple"
 - meta.source_prompt_id = "P1_ISTAX_01"
 - meta.version = "1.0"
 
-Seed industries (use for inspiration): [digital_services, SaaS, consultancy, holding_companies].
+Diversity seeds:
+- Jurisdictions (use a balanced mix): ["uk", "us", "de", "ae"]
+- Industries (use for inspiration): [digital_services, SaaS, consultancy, holding_companies]
 
 For each card:
-- Write a realistic short scenario in input.scenario (one sentence to two sentences).
-- Include realistic constraints: permanent establishment risk, VAT/sales tax considerations, presence of local employees.
-- meta.rationale must explain why mu_ibc is recommended for the stated goals under the scenario facts.
-- output.policy_refs: a list containing a single internal tag, like ["internal_policy:intl_tax_structuring_v1"].
+- Write a realistic short scenario in input.scenario (one to two sentences) for one of the jurisdictions and industries.
+- The scenario should include realistic constraints like permanent establishment risk, VAT/sales tax considerations, or the presence of local employees.
+- Populate input.jurisdiction with the chosen jurisdiction for the scenario.
+- Populate input.assumptions and input.constraints with realistic, 1-sentence details based on the scenario.
+- Provide meta.rationale: 1–3 sentences explaining why mu_ibc is recommended for the stated goals under the scenario facts.
+- Set output.policy_refs to a list containing a single internal tag, like ["internal_policy:intl_tax_structuring_v1"].
 
-Emit the error object for invalid jurisdictions. Output exactly 225 flashcards only.
+If a jurisdiction outside the allowed set appears, emit {"error":"invalid_jurisdiction","value":"<value>"}.

--- a/prompts/P1_IST_01.txt
+++ b/prompts/P1_IST_01.txt
@@ -1,7 +1,6 @@
-You are a structured dataset generator. Generate exactly 225 JSON flashcards (NDJSON). Conform to v1.0 schema.
+You are a structured dataset generator. Generate JSON flashcards as NDJSON (one JSON object per line, no extra text). Produce exactly 225 flashcards. Each JSON object MUST conform to the v1.0 flashcard schema provided to you: input, output, meta.
 
-Fixed fields:
-- input.jurisdiction ∈ {"uk","de"} (only these two; each card should specify one)
+Constraints / fixed fields:
 - input.goals = ["international_trade"]
 - output.recommended_structures = ["mu_ibc"]
 - meta.subsection = "intl_simple_trade"
@@ -9,13 +8,16 @@ Fixed fields:
 - meta.source_prompt_id = "P1_IST_01"
 - meta.version = "1.0"
 
-Diversity seeds: [import/export, e-commerce, software_licensing, digital_services, SaaS].
+Diversity seeds:
+- Jurisdictions (use a balanced mix): ["uk", "de"]
+- Industries (use for inspiration): [import/export, e-commerce, software_licensing, digital_services, SaaS]
 
 For each card:
-- Write a realistic short scenario in input.scenario (one sentence to two sentences).
-- Make it realistic for the given jurisdiction and trade pattern (include cross-border customers, logistics).
-- Provide input.assumptions and input.constraints.
-- meta.rationale: 1–3 sentences explaining choice of mu_ibc.
-- output.policy_refs: a list containing a single internal tag, like ["internal_policy:intl_trade_guidance"].
+- Write a realistic short scenario in input.scenario (one to two sentences) for one of the jurisdictions and industries.
+- The scenario should be realistic for the given jurisdiction and trade pattern (include cross-border customers, logistics).
+- Populate input.jurisdiction with the chosen jurisdiction for the scenario.
+- Populate input.assumptions and input.constraints with realistic, 1-sentence details.
+- Provide meta.rationale: 1–3 sentences explaining the choice of mu_ibc for the scenario.
+- Set output.policy_refs to a list containing a single internal tag, like ["internal_policy:intl_trade_guidance"].
 
-If a jurisdiction outside allowed set appears, emit {"error":"invalid_jurisdiction","value":"<value>"}. Output exactly 225 flashcards only.
+If a jurisdiction outside the allowed set appears, emit {"error":"invalid_jurisdiction","value":"<value>"}.


### PR DESCRIPTION
This commit fixes the final two problematic Phase 1 prompts (`P1_IST_01.txt` and `P1_ISTAX_01.txt`) by refactoring them to match the explicit, structured format of the known-working prompts.

This change addresses errors where the AI was failing to generate required properties like 'output' and 'recommended_structures'.

This commit, combined with the previous fixes to `P1_ZEC_01.txt` and the `generate_flashcards.py` validation schema, should now resolve all reported issues with the Phase 1 data generation process. All P1 prompts now follow a consistent, robust structure.