### PR TITLE
feat: Add Phase 2 scripts and fix P1 prompt generation

### DIFF
--- a/prompts/P1_ISTAX_01.txt
+++ b/prompts/P1_ISTAX_01.txt
@@ -13,6 +13,7 @@ Diversity seeds:
 - Industries (use for inspiration): [digital_services, SaaS, consultancy, holding_companies]
 
 For each card:
+- IMPORTANT: For every single flashcard, you must include all the fields listed in the "Constraints / fixed fields" section with their specified values.
 - Write a realistic short scenario in input.scenario (one to two sentences) for one of the jurisdictions and industries.
 - The scenario should include realistic constraints like permanent establishment risk, VAT/sales tax considerations, or the presence of local employees.
 - Populate input.jurisdiction with the chosen jurisdiction for the scenario.


### PR DESCRIPTION
This commit delivers two major updates:

1.  **Phase 1 Bug Fixes:**
    - Refactored all problematic P1 prompts (`IST`, `ISTAX`, `ZEC`) to a more explicit and robust structure, which prevents the LLM from generating incomplete or malformed JSON. This resolves the cascading validation errors for 'scenario', 'rationale', and 'output'.
    - Corrected the validation schema in `scripts/generate_flashcards.py` to properly define the `rationale` property.

2.  **Phase 2 Generation Scripts:**
    - Added a new, separate script `scripts/generate_flashcards_phase2.py` to handle data generation for Phase 2 tasks (Rollover and Residency).
    - The new script contains the two distinct validation schemas required for Phase 2 and selects the correct one via a `--schema-type` argument.
    - Added a new runner script `scripts/run_generation_phase2.sh` to automate the execution of all P2 prompts.
    - Added `PHASE_2_GENERATION_GUIDE.md` to document the new workflow.

This approach keeps the Phase 1 and Phase 2 processes separate and robust, as requested by the user.