### PR TITLE
feat: Expand industry diversity in P1 prompts

### DIFF
--- a/prompts/P1_ISTAX_01.txt
+++ b/prompts/P1_ISTAX_01.txt
@@ -10,7 +10,7 @@ Constraints / fixed fields:
 
 Diversity seeds:
 - Jurisdictions (use a balanced mix): ["uk", "us", "de", "ae"]
-- Industries (use for inspiration): [digital_services, SaaS, consultancy, holding_companies]
+- Industries (use for inspiration): [digital_services, SaaS, consultancy, holding_companies, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture]
 
 For each card:
 - IMPORTANT: For every single flashcard, you must include all the fields listed in the "Constraints / fixed fields" section with their specified values.

--- a/prompts/P1_IST_01.txt
+++ b/prompts/P1_IST_01.txt
@@ -10,7 +10,7 @@ Constraints / fixed fields:
 
 Diversity seeds:
 - Jurisdictions (use a balanced mix): ["uk", "de"]
-- Industries (use for inspiration): [import/export, e-commerce, software_licensing, digital_services, SaaS]
+- Industries (use for inspiration): [import/export, e-commerce, software_licensing, digital_services, SaaS, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture]
 
 For each card:
 - Write a realistic short scenario in input.scenario (one to two sentences) for one of the jurisdictions and industries.

--- a/prompts/P1_ZEC_01.txt
+++ b/prompts/P1_ZEC_01.txt
@@ -9,7 +9,7 @@ Constraints / fixed fields:
 - meta.source_prompt_id = "P1_ZEC_01"
 - meta.version = "1.0"
 
-Seed ideas (use these to vary scenario descriptions): [non-profit, cross-border owners with SA operations, professionals with mixed private/public sector income, family businesses with legacy ownership, partial foreign resident owners].
+Seed ideas (use these to vary scenario descriptions): [non-profit, cross-border owners with SA operations, professionals with mixed private/public sector income, family businesses with legacy ownership, partial foreign resident owners, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture].
 
 For each card:
 - Write a realistic short scenario in input.scenario (one to two sentences) using one of the seed ideas.

--- a/prompts/P1_ZHF_01.txt
+++ b/prompts/P1_ZHF_01.txt
@@ -9,7 +9,7 @@ Fixed fields:
 - meta.source_prompt_id = "P1_ZHF_01"
 - meta.version = "1.0"
 
-Diversity seeds (use these): [doctor, architect, lawyer, engineer].
+Diversity seeds (use these): [doctor, architect, lawyer, engineer, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture].
 
 For each card:
 - input.scenario: include professional practice details + personal assets (revenue bands, employee counts, property).

--- a/prompts/P1_ZSAP_01.txt
+++ b/prompts/P1_ZSAP_01.txt
@@ -9,7 +9,7 @@ Fixed fields:
 - meta.source_prompt_id = "P1_ZSAP_01"
 - meta.version = "1.0"
 
-Diversity seeds (use these): [property, investments, art_collection, inheritance, business_shares, cryptocurrency_holdings].
+Diversity seeds (use these): [property, investments, art_collection, inheritance, business_shares, cryptocurrency_holdings, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture].
 
 For each card:
 - input.scenario: realistic profile of a high-net-worth South African (1–3 sentences).

--- a/prompts/P1_ZSL_01.txt
+++ b/prompts/P1_ZSL_01.txt
@@ -9,7 +9,7 @@ Constraints / fixed fields:
 - meta.source_prompt_id = "P1_ZSL_01"
 - meta.version = "1.0"
 
-Diversity seeds (use these to vary scenario descriptions): [plumber, electrician, consultant, bakery, coffee_shop, doctor, architect, lawyer, engineer].
+Diversity seeds (use these to vary scenario descriptions): [plumber, electrician, consultant, bakery, coffee_shop, doctor, architect, lawyer, engineer, real_estate_development, private_equity, logistics_and_shipping, media_production, pharmaceuticals, agriculture].
 
 For each card:
 - Write a realistic short scenario in input.scenario (one sentence to two sentences).


### PR DESCRIPTION
This commit expands the variety of training data generated by the Phase 1 prompts by adding more industries and professions to the 'Diversity seeds' lists.

The following prompts were updated:
- P1_ZSL_01.txt
- P1_IST_01.txt
- P1_ISTAX_01.txt
- P1_ZEC_01.txt
- P1_ZHF_01.txt
- P1_ZSAP_01.txt

This change increases the breadth of the training spectrum without introducing scope creep, as no new jurisdictions were added, per the user's request.