### PR TITLE
feat: Point generation scripts to local LLM server

### DIFF
--- a/scripts/generate_flashcards.py
+++ b/scripts/generate_flashcards.py
@@ -60,7 +60,10 @@ def generate_from_llm(prompt, api_key):
     """
     print(f"INFO: Calling OpenAI API...")
     try:
-        client = openai.OpenAI(api_key=api_key)
+        client = openai.OpenAI(
+            base_url="http://127.0.0.1:1234/v1",
+            api_key="not-needed"
+        )
         response = client.chat.completions.create(
             model="gpt-4o",
             messages=[

--- a/scripts/generate_flashcards_phase2.py
+++ b/scripts/generate_flashcards_phase2.py
@@ -98,7 +98,10 @@ def generate_from_llm(prompt, api_key):
     """
     print(f"INFO: Calling OpenAI API...")
     try:
-        client = openai.OpenAI(api_key=api_key)
+        client = openai.OpenAI(
+            base_url="http://127.0.0.1:1234/v1",
+            api_key="not-needed"
+        )
         response = client.chat.completions.create(
             model="gpt-4o",
             messages=[


### PR DESCRIPTION
This commit updates both data generation scripts to use a local LLM server instead of the public OpenAI API.

- Modified `scripts/generate_flashcards.py` (for Phase 1) to point to `http://127.0.0.1:1234/v1`.
- Modified `scripts/generate_flashcards_phase2.py` (for Phase 2) to point to the same local server address.

This allows the user to generate all training data using a local model, such as Hermes, running in LM Studio or Ollama.