### PR TITLE
Fix(scripts): Add jurisdiction fallback for LLM generation

### DIFF
--- a/scripts/generate_flashcards.py
+++ b/scripts/generate_flashcards.py
@@ -112,6 +112,11 @@ def generate_and_write_flashcards(prompt, output_filepath, debug_filepath=None):
                         total_count += 1
                         try:
                             flashcard = json.loads(line)
+                            # Fallback for missing jurisdiction
+                            if 'input' in flashcard and isinstance(flashcard.get('input'), dict) and 'jurisdiction' not in flashcard['input']:
+                                print("INFO: 'jurisdiction' is missing. Adding default 'za'.")
+                                flashcard['input']['jurisdiction'] = 'za'
+
                             if validate_flashcard(flashcard):
                                 f.write(json.dumps(flashcard) + '\n')
                                 valid_count += 1
@@ -125,6 +130,11 @@ def generate_and_write_flashcards(prompt, output_filepath, debug_filepath=None):
             total_count += 1
             try:
                 flashcard = json.loads(buffer)
+                # Fallback for missing jurisdiction
+                if 'input' in flashcard and isinstance(flashcard.get('input'), dict) and 'jurisdiction' not in flashcard['input']:
+                    print("INFO: 'jurisdiction' is missing. Adding default 'za'.")
+                    flashcard['input']['jurisdiction'] = 'za'
+
                 if validate_flashcard(flashcard):
                     with open(output_filepath, 'a') as f:
                         f.write(json.dumps(flashcard) + '\n')


### PR DESCRIPTION
This commit makes the `generate_flashcards.py` script more resilient to common errors from local LLMs.

Specifically, it addresses an issue where the LLM would occasionally omit the required `jurisdiction` field from the generated flashcards, causing them to fail validation and be discarded.

The script now checks for the absence of this field and, if it's missing, inserts the default value of `"za"` before passing the flashcard to the validator. This improves the yield of valid flashcards from flaky models and makes the overall data generation process more reliable.